### PR TITLE
bug(#32): Fixed sidebar brand link

### DIFF
--- a/src/ui/mint-nft/index.html
+++ b/src/ui/mint-nft/index.html
@@ -15,7 +15,7 @@
 </head>
 <body>
   <div class="d-flex flex-column flex-shrink-0 p-3" style="position: absolute; max-width: 240px; min-height: 100vh; border-right: solid 1px rgb(0, 0, 0)">
-    <a href="" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-decoration-none"><span>Stable Angel</span></a>
+    <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-decoration-none"><span>Stable Angel</span></a>
     <hr>
     <ul class="nav nav-pills flex-column mb-auto">
       <li class="nav-item"><a href="#" class="nav-link active">Mint NFT</a></li>


### PR DESCRIPTION
The sidebar brand at: `src/ui/mint-nft/index.html:18` now links to `/`.

Fixes #32