### PR TITLE
bug(#37): Fixed Sidebar of `/mint-nft`

### DIFF
--- a/src/ui/mint-nft/index.html
+++ b/src/ui/mint-nft/index.html
@@ -18,8 +18,8 @@
     <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-decoration-none"><span>Stable Angel</span></a>
     <hr>
     <ul class="nav nav-pills flex-column mb-auto">
-      <li class="nav-item"><a href="#" class="nav-link active">Mint NFT</a></li>
-      <li class="nav-item"><a href="#" class="nav-link">Wrap LP</a></li>
+      <li class="nav-item"><a href="/mint-nft" class="nav-link active">Mint NFT</a></li>
+      <li class="nav-item"><a href="/wrap-lp" class="nav-link">Wrap LP</a></li>
       <li class="nav-item"><a href="#" class="nav-link">Borrow SILK</a></li>
       <li class="nav-item"><a href="#" class="nav-link">Portfolio</a></li>
     </ul>


### PR DESCRIPTION
The Sidebar of `/mint-nft` at: `src/ui/mint-nft/index.html:21` now includes valid `href`s.

Fixes #37