### PR TITLE
docs(#80): Fixed link to `DESIGN.md` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 Deposit SILK --> the contract then buys LPs @ 25% each (SILK + CMST -- SILK + USDT -- SILK + USDC [all these are Shade pools] + saUSDC + saUSDT [blizzard finance]) --> contract can claim all rewards associated with each LP --> all rewards are traded for SILK once a quarter --> SILK is deposited into Shade Earn (found in their borrow section) --> rewards from 'earn' are claimed by the contract and sent to the owners wallet once each quarter.
 --------------------------------------------------------------------------------
 
-See [DESIGN.md](https://github.com/SisuStake/Secret-Hackathon).
+See [DESIGN.md](https://github.com/SisuStake/Secret-Hackathon/blob/master/DESIGN.md).


### PR DESCRIPTION
The reference `DESIGN.md` now references `DESIGN.md` on branch `master` (https://github.com/SisuStake/Secret-Hackathon/blob/master/DESIGN.md).

Fixes #80