### PR TITLE
bug(#89): Fixed `<PortfolioTableHeader />` values

### DIFF
--- a/src/lib/components/tables/portfolio-header.svelte
+++ b/src/lib/components/tables/portfolio-header.svelte
@@ -5,6 +5,6 @@
     <th scope="col">Volume (24h)</th>
     <th scope="col">APY</th>
     <th scope="col">Total Fees</th>
-    <th scope="col">Total Total</th>
+    <th scope="col">Value</th>
   </tr>
 </thead>


### PR DESCRIPTION
The 6th header of `<PortfolioTableHeader />` corrected to `Value`

Fixes #89