### PR TITLE
feat(#91): Cleaned up Mockup Styles

### DIFF
--- a/src/lib/components/buttons/submit.svelte
+++ b/src/lib/components/buttons/submit.svelte
@@ -2,4 +2,4 @@
   export let value
 </script>
 
-<input type="submit" {value}>
+<input type="submit" {value} class="btn btn-primary">

--- a/src/lib/components/buttons/swap.svelte
+++ b/src/lib/components/buttons/swap.svelte
@@ -4,5 +4,5 @@
   }
 </style>
 
-<button>Swap</button>
+<button class="btn btn-primary">Swap</button>
 

--- a/src/lib/components/forms/mint-nft.svelte
+++ b/src/lib/components/forms/mint-nft.svelte
@@ -16,6 +16,7 @@
     border-radius: 8px;
     display: inline-block;
     padding: 16px;
+    text-align: center;
   }
 </style>
 

--- a/src/lib/components/forms/wrap-lp.svelte
+++ b/src/lib/components/forms/wrap-lp.svelte
@@ -16,6 +16,7 @@
     border: 1px solid rgb(0, 0, 0);
     border-radius: 8px;
     padding: 16px;
+    text-align: center;
   }
 
   fieldset {


### PR DESCRIPTION
Cleanup Mockup Styles

 - [x] Buttons (`<Submit />` & `<Swap />`) now have class `.btn .btn-primary`.
 - [x] Forms (`<MintNFTForm />` & `</WrapLPForm />` now have `text-align: center`.

Fixes #91